### PR TITLE
feat(NbtReaderVb): 对 vb .net 的适配

### DIFF
--- a/PlainNamedBinaryTag/PlainNamedBinaryTag.csproj
+++ b/PlainNamedBinaryTag/PlainNamedBinaryTag.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NbtReaderVb.cs" />
     <Compile Include="NbtReader.cs" />
     <Compile Include="NbtWriter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
定义了类 `NbtReaderVb`，以允许在 vb .net 中访问 `NbtReader` 的功能。

瞎糊的测试代码如下，成功输出了正确的 xml 结构。

```cs
var reader = new NbtReaderVb("C:\\***\\.minecraft\\versions\\1.20.6-Fabric 0.16.0\\saves\\新的世界\\level.dat",true);
var nbttype = NbtType.TCompound;
Console.WriteLine(reader.ReadNbtAsXml(out nbttype));
```

如有问题请指出，感谢！